### PR TITLE
Decrement the number of running connections after a failed request

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -81,7 +81,9 @@ function processQueue() {
       processQueue();
     },
     function({error}: IRequestCallbackFailure) {
+      running--;
       next.callback(error);
+      processQueue();
     }
   );
 }


### PR DESCRIPTION
After 20 failed connections the prismic api stops responding. The error handler was not decrementing the running connections counter and was not processing the next request in the query