### PR TITLE
Fix predicates with numbers being cast to string

### DIFF
--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -32,6 +32,8 @@ export const Operator = {
 function encode(value: string | string[]): string | null {
   if(typeof value === 'string') {
     return `"${value}"`;
+  } else if(typeof value === 'number') {
+      return value + '';
   } else if(value instanceof Array) {
     return `[${value.map(v => encode(v)).join(',')}]`;
   } else {


### PR DESCRIPTION
Creating predicates with number(s) as value would cast them to strings, resulting in a 400 error. Maybe instead of returning `null` for unknown types there should be `value.toString()` or `JSON.stringify(value)` and leave it to the user what that results in (e.g. implement a custom `toJSON` method)? Anyway, this fixes numbers.

## Before

```javascript
Prismic.Predicates.at('my.type.number', 5); // [:d = at(my.type.number, "5")]
Prismic.Predicates.any('my.type.number', [3, 4, 5]); // [:d = any(my.type.number, ["3","4","5"])]
```

## After

```javascript
Prismic.Predicates.at('my.type.number', 5); // [:d = at(my.type.number, 5)]
Prismic.Predicates.any('my.type.number', [3, 4, 5]); // [:d = any(my.type.number, [3,4,5])]
```