### PR TITLE
Bugfix: Prismic uses ambient type definition for "Document"

### DIFF
--- a/d.ts/ApiSearchResponse.d.ts
+++ b/d.ts/ApiSearchResponse.d.ts
@@ -1,3 +1,4 @@
+import { Document } from "./documents";
 export default interface ApiSearchResponse {
     page: number;
     results_per_page: number;

--- a/d.ts/ResolvedApi.d.ts
+++ b/d.ts/ResolvedApi.d.ts
@@ -4,6 +4,7 @@ import { SearchForm, Form } from './form';
 import ApiSearchResponse from './ApiSearchResponse';
 import HttpClient from './HttpClient';
 import { Client } from './client';
+import { Document } from "./documents";
 export declare const PREVIEW_COOKIE = "io.prismic.preview";
 export declare const EXPERIMENT_COOKIE = "io.prismic.experiment";
 export interface Ref {

--- a/d.ts/client.d.ts
+++ b/d.ts/client.d.ts
@@ -1,4 +1,5 @@
 import ResolvedApi, { QueryOptions } from './ResolvedApi';
+import { Document } from "./documents";
 import ApiSearchResponse from './ApiSearchResponse';
 import { LazySearchForm } from './form';
 import { RequestCallback } from './request';

--- a/src/ApiSearchResponse.ts
+++ b/src/ApiSearchResponse.ts
@@ -1,3 +1,4 @@
+import { Document } from "./documents";
 export default interface ApiSearchResponse {
   page: number;
   results_per_page: number;

--- a/src/ResolvedApi.ts
+++ b/src/ResolvedApi.ts
@@ -7,6 +7,7 @@ import Cookies from './Cookies';
 import ApiSearchResponse from './ApiSearchResponse';
 import HttpClient from './HttpClient';
 import { Client } from './client';
+import { Document } from "./documents";
 
 export const PREVIEW_COOKIE = 'io.prismic.preview';
 export const EXPERIMENT_COOKIE = 'io.prismic.experiment';
@@ -112,10 +113,10 @@ export default class ResolvedApi implements Client {
   /**
    * Query the repository
    */
-  query(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<ApiSearchResponse>, cb: RequestCallback<ApiSearchResponse> = () => {}): Promise<ApiSearchResponse> {
+  query(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<ApiSearchResponse>, cb: RequestCallback<ApiSearchResponse> = () => { }): Promise<ApiSearchResponse> {
     const { options, callback } = typeof optionsOrCallback === 'function'
-        ? { options: {} as QueryOptions, callback: optionsOrCallback }
-    : { options: optionsOrCallback || {}, callback: cb };
+      ? { options: {} as QueryOptions, callback: optionsOrCallback }
+      : { options: optionsOrCallback || {}, callback: cb };
 
     let form = this.everything();
     for (const key in options) {
@@ -148,8 +149,8 @@ export default class ResolvedApi implements Client {
    */
   queryFirst(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document> {
     const { options, callback } = typeof optionsOrCallback === 'function'
-        ? { options: {} as QueryOptions, callback: optionsOrCallback }
-        : { options: optionsOrCallback || {}, callback: cb || (() => {}) };
+      ? { options: {} as QueryOptions, callback: optionsOrCallback }
+      : { options: optionsOrCallback || {}, callback: cb || (() => { }) };
 
     options.page = 1;
     options.pageSize = 1;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import ResolvedApi, { QueryOptions, EXPERIMENT_COOKIE, PREVIEW_COOKIE } from './ResolvedApi';
+import { Document } from "./documents";
 import ApiSearchResponse from './ApiSearchResponse';
 import { SearchForm, LazySearchForm } from './form';
 import { Experiment } from './experiments';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
-import PrismicPredicates  from './Predicates';
+import PrismicPredicates from './Predicates';
 import { Experiments as PrismicExperiment } from './experiments';
 import { DefaultClient } from './client';
 import PrismicApi, { ApiOptions } from './Api';
 import ResolvedApi, { EXPERIMENT_COOKIE, PREVIEW_COOKIE } from './ResolvedApi';
+import { Document } from "./documents";
 
 namespace Prismic {
 


### PR DESCRIPTION
Files like `ApiSearchResponse` currently produce values of `Document` type, but `Document` is not imported. That means that, instead of using Prismic's definition of Document, the default definition is used instead. As a result, clients using the type definitions get the wrong type (in my case, the type representing HTML Documents, provided by `react`).  I don't know if this ever worked correctly, but I don't see how it could do.

This pull request fixes this by simple importing Document on all relevant files.