### PR TITLE
Add missing imports

### DIFF
--- a/d.ts/ApiSearchResponse.d.ts
+++ b/d.ts/ApiSearchResponse.d.ts
@@ -1,3 +1,4 @@
+import { Document } from "./documents";
 export default interface ApiSearchResponse {
     page: number;
     results_per_page: number;

--- a/d.ts/ResolvedApi.d.ts
+++ b/d.ts/ResolvedApi.d.ts
@@ -1,3 +1,4 @@
+import { Document } from "./documents";
 import { RequestCallback } from './request';
 import { Experiment, Experiments } from './experiments';
 import { SearchForm, Form } from './form';

--- a/d.ts/client.d.ts
+++ b/d.ts/client.d.ts
@@ -1,3 +1,4 @@
+import { Document } from "./documents";
 import ResolvedApi, { QueryOptions } from './ResolvedApi';
 import ApiSearchResponse from './ApiSearchResponse';
 import { LazySearchForm } from './form';

--- a/src/ApiSearchResponse.ts
+++ b/src/ApiSearchResponse.ts
@@ -1,3 +1,5 @@
+import { Document } from "./documents";
+
 export default interface ApiSearchResponse {
   page: number;
   results_per_page: number;

--- a/src/ResolvedApi.ts
+++ b/src/ResolvedApi.ts
@@ -1,3 +1,4 @@
+import { Document } from "./documents";
 import { RequestHandler, RequestCallback } from './request';
 import { ApiCache } from './cache';
 import { Experiment, Experiments } from './experiments';

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,4 @@
+import { Document } from "./documents";
 import ResolvedApi, { QueryOptions, EXPERIMENT_COOKIE, PREVIEW_COOKIE } from './ResolvedApi';
 import ApiSearchResponse from './ApiSearchResponse';
 import { SearchForm, LazySearchForm } from './form';


### PR DESCRIPTION
I noticed that the `Document` interface is not imported in the classes that use it. So in my TypeScript-project all the things related to this interface are broken :(

Please merge this PR asap  :+1: 