### PR TITLE
Fix Ref interface

### DIFF
--- a/d.ts/ResolvedApi.d.ts
+++ b/d.ts/ResolvedApi.d.ts
@@ -10,7 +10,7 @@ export declare const EXPERIMENT_COOKIE = "io.prismic.experiment";
 export interface Ref {
     ref: string;
     label: string;
-    isMasterRef: string;
+    isMasterRef: boolean;
     scheduledAt: string;
     id: string;
 }


### PR DESCRIPTION
`isMasterRef` was described as a string, but the API returns a boolean, which made following the docs to configure in-site preview a pain because `api.refs.find(ref => ref.isMasterRef)` tries to compare a string to a boolean 😢 