### PR TITLE
added check for options.req in addition to this.options.req in ResolvededApi.query method

### DIFF
--- a/src/ResolvedApi.ts
+++ b/src/ResolvedApi.ts
@@ -125,8 +125,8 @@ export default class ResolvedApi implements Client {
     if (!options.ref) {
       // Look in cookies if we have a ref (preview or experiment)
       let cookieString = '';
-      if (this.options.req) { // NodeJS
-        cookieString = this.options.req.headers['cookie'] || '';
+      if (options.req || this.options.req) { // NodeJS
+        cookieString = (options.req || this.options.req).headers['cookie'] || '';
       } else if (typeof window !== 'undefined' && window.document) { // Browser
         cookieString = window.document.cookie || '';
       }


### PR DESCRIPTION
According to line 147 of ResolvedApi.ts (see below), I should be able to pass in the Node.js request object as 'req'. However, the request object is not being used in the underlying `query(...)` method. This PR offers a fix.

```
/**
   * Retrieve the document returned by the given query
   * @param {string|array|Predicate} the query
   * ---> @param {object} additional parameters. In NodeJS, pass the request as 'req'.
   * @param {function} callback(err, doc)
   */
  queryFirst(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document> {
```

In the query method below, it is only checking `this.options.req` and does not check for the existence of the `options.req` key of the options passed into the `query(...) method`

```
-->  if (this.options.req) { // NodeJS
        cookieString = this.options.req.headers['cookie'] || '';
      } else if (typeof window !== 'undefined' && window.document) { // Browser
        cookieString = window.document.cookie || '';
      }
```
