### PR TITLE
Added linked_documents into the document type

### DIFF
--- a/d.ts/documents.d.ts
+++ b/d.ts/documents.d.ts
@@ -6,6 +6,7 @@ export interface Document {
     tags: string[];
     slugs: string[];
     lang?: string;
+    linked_documents?: string[];
     alternate_languages: string[];
     first_publication_date: string | null;
     last_publication_date: string | null;

--- a/src/documents.ts
+++ b/src/documents.ts
@@ -6,6 +6,7 @@ export interface Document {
   tags: string[];
   slugs: string[];
   lang ?: string;
+  linked_documents ?: string[];
   alternate_languages: string[];
   first_publication_date: string | null;
   last_publication_date: string | null;


### PR DESCRIPTION
Querying the Prismic Api V2 returns a document model which includes a linked_documents field. This field is not included in the Document type definition, causing issues when writing unit tests with and defining fixtures based on the API Data.