### PR TITLE
Expose into a function the logic to get the ref

### DIFF
--- a/d.ts/ResolvedApi.d.ts
+++ b/d.ts/ResolvedApi.d.ts
@@ -76,6 +76,7 @@ export default class ResolvedApi implements Client {
      */
     ref(label: string): string | null;
     currentExperiment(): Experiment | null;
+    getResolvedRef(): string;
     /**
      * Query the repository
      */

--- a/test/api.js
+++ b/test/api.js
@@ -107,7 +107,7 @@ describe('Api', function() {
         assert.strictEqual(document.lang, 'en-us');
 
         done();
-      })
+      });
     }).catch(done);
   });
 
@@ -159,6 +159,15 @@ describe('Api', function() {
 
         done();
       });
+    }).catch(done);
+  });
+
+  it('should get the resolved ref', function(done) {
+    getApi().then(function(api) {
+      const resolvedRef = api.getResolvedRef();
+      assert.strictEqual(api.master(), resolvedRef);
+
+      done();
     }).catch(done);
   });
 });


### PR DESCRIPTION
Expose into a function the way we resolve the ref we're going to use (master ref, preview ref or experiment ref).
This exposed function is useful for `apollo-link-prismic`.