### PR TITLE
Feature: Adds boolean value in type PredicateValue.

### DIFF
--- a/src/Predicates.ts
+++ b/src/Predicates.ts
@@ -29,7 +29,7 @@ const OPERATOR = {
   GeopointNear: 'geopoint.near',
 };
 
-type PredicateValue = string | number | Date;
+type PredicateValue = boolean | string | number | Date;
 
 function encode(value: PredicateValue | PredicateValue[]): string {
   if (typeof value === 'string') {
@@ -40,6 +40,8 @@ function encode(value: PredicateValue | PredicateValue[]): string {
     return value.getTime().toString();
   } else if (Array.isArray(value)) {
     return `[${value.map(v => encode(v)).join(',')}]`;
+  } else if (typeof value === "boolean") {
+    return value.toString()
   } else {
     throw new Error(`Unable to encode ${value} of type ${typeof value}`);
   }

--- a/test/predicates.js
+++ b/test/predicates.js
@@ -12,6 +12,14 @@ describe('Predicates', function() {
     );
   });
 
+  it('should build at query with boolean value', function() {
+    assert.strictEqual(
+      Prismic.Predicates.at('my.product.pinned', true),
+      '[at(my.product.pinned, true)]'
+    );
+  });
+
+
   it('should build at query with date value', function() {
     var date = new Date();
     assert.strictEqual(
@@ -61,6 +69,13 @@ describe('Predicates', function() {
     assert.strictEqual(
       Prismic.Predicates.not('my.product.price', 10),
       '[not(my.product.price, 10)]'
+    );
+  });
+
+  it('should build not query with boolean value', function() {
+    assert.strictEqual(
+      Prismic.Predicates.not('my.product.pinned', false),
+      '[not(my.product.pinned, false)]'
     );
   });
 
@@ -388,4 +403,3 @@ describe('Predicates', function() {
     );
   });
 });
-


### PR DESCRIPTION
The api is able to handle Predicates with `boolean` values (https://prismic.io/docs/rest-api/query-the-api/query-by-a-field#14_0-a-boolean-field). But the `PredicateValue` does not contain `boolean` and the `encode` method does not encode booleans.

 