### PR TITLE
Fix boolean encoding

### DIFF
--- a/src/Predicates.ts
+++ b/src/Predicates.ts
@@ -32,7 +32,7 @@ const OPERATOR = {
 type PredicateValue = string | number | Date;
 
 function encode(value: PredicateValue | PredicateValue[]): string {
-  if (typeof value === 'string') {
+  if (typeof value === 'string' || typeof value === 'boolean') {
     return `"${value}"`;
   } else if (typeof value === 'number') {
     return value.toString();


### PR DESCRIPTION
One liner that correctly encodes boolean values into strings