### PR TITLE
Clean up query method definition

### DIFF
--- a/d.ts/ResolvedApi.d.ts
+++ b/d.ts/ResolvedApi.d.ts
@@ -1,4 +1,4 @@
-import { Document } from "./documents";
+import { Document } from './documents';
 import { RequestCallback } from './request';
 import { Experiment, Experiments } from './experiments';
 import { SearchForm, Form } from './form';
@@ -86,14 +86,14 @@ export default class ResolvedApi implements Client {
     /**
      * Query the repository
      */
-    query(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
+    query(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
     /**
      * Retrieve the document returned by the given query
      * @param {string|array|Predicate} the query
      * @param {object} additional parameters. In NodeJS, pass the request as 'req'.
      * @param {function} callback(err, doc)
      */
-    queryFirst(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document>;
+    queryFirst(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document>;
     /**
      * Retrieve the document with the given id
      */

--- a/d.ts/client.d.ts
+++ b/d.ts/client.d.ts
@@ -6,8 +6,8 @@ import { RequestCallback } from './request';
 import Api, { ApiOptions } from './Api';
 import { PreviewResolver } from './PreviewResolver';
 export interface Client {
-    query(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
-    queryFirst(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<Document>, cb: RequestCallback<Document>): Promise<Document>;
+    query(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
+    queryFirst(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document>;
     getByID(id: string, options: QueryOptions, cb: RequestCallback<Document>): Promise<Document>;
     getByIDs(ids: string[], options: QueryOptions, cb: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
     getByUID(type: string, uid: string, options: QueryOptions, cb: RequestCallback<Document>): Promise<Document>;
@@ -18,13 +18,12 @@ export interface Client {
 }
 export declare class DefaultClient implements Client {
     api: Api;
-    resolvedApi: ResolvedApi;
     constructor(url: string, options?: ApiOptions);
     getApi(): Promise<ResolvedApi>;
     everything(): LazySearchForm;
     form(formId: string): LazySearchForm;
-    query(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
-    queryFirst(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document>;
+    query(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
+    queryFirst(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document>;
     getByID(id: string, options: QueryOptions, cb?: RequestCallback<Document>): Promise<Document>;
     getByIDs(ids: string[], options: QueryOptions, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
     getByUID(type: string, uid: string, options: QueryOptions, cb?: RequestCallback<Document>): Promise<Document>;

--- a/src/ResolvedApi.ts
+++ b/src/ResolvedApi.ts
@@ -1,6 +1,5 @@
-import { Document } from "./documents";
-import { RequestHandler, RequestCallback } from './request';
-import { ApiCache } from './cache';
+import { Document } from './documents';
+import { RequestCallback } from './request';
 import { Experiment, Experiments } from './experiments';
 import { SearchForm, Form } from './form';
 import Predicates from './Predicates';
@@ -122,7 +121,7 @@ export default class ResolvedApi implements Client {
   /**
    * Query the repository
    */
-  query(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<ApiSearchResponse>, cb: RequestCallback<ApiSearchResponse> = () => {}): Promise<ApiSearchResponse> {
+  query(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse>, cb: RequestCallback<ApiSearchResponse> = () => {}): Promise<ApiSearchResponse> {
     const { options, callback } = typeof optionsOrCallback === 'function'
         ? { options: {} as QueryOptions, callback: optionsOrCallback }
     : { options: optionsOrCallback || {}, callback: cb };
@@ -156,10 +155,10 @@ export default class ResolvedApi implements Client {
    * @param {object} additional parameters. In NodeJS, pass the request as 'req'.
    * @param {function} callback(err, doc)
    */
-  queryFirst(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document> {
+  queryFirst(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document> {
     const { options, callback } = typeof optionsOrCallback === 'function'
         ? { options: {} as QueryOptions, callback: optionsOrCallback }
-        : { options: {...optionsOrCallback} || {}, callback: cb || (() => {}) };
+        : { options: optionsOrCallback || {}, callback: cb || (() => {}) };
 
     options.page = 1;
     options.pageSize = 1;
@@ -197,8 +196,8 @@ export default class ResolvedApi implements Client {
    */
   getByUID(type: string, uid: string, maybeOptions?: QueryOptions, cb?: RequestCallback<Document>): Promise<Document> {
     const options = maybeOptions ? {...maybeOptions} : {};
-    if(options.lang === "*") throw new Error("FORDIDDEN. You can't use getByUID with *, use the predicates instead.")
-    if(!options.page) options.page = 1;
+    if (options.lang === '*') throw new Error("FORBIDDEN. You can't use getByUID with *, use the predicates instead.");
+    if (!options.page) options.page = 1;
 
     return this.queryFirst(Predicates.at(`my.${type}.uid`, uid), options, cb);
   }
@@ -228,7 +227,7 @@ export default class ResolvedApi implements Client {
   }
 
   previewSession(token: string, linkResolver: LinkResolver, defaultUrl: string, cb?: RequestCallback<string>): Promise<string> {
-    console.warn('previewSession function is deprecated in favor of getPreviewResolver function.')
+    console.warn('previewSession function is deprecated in favor of getPreviewResolver function.');
     return new Promise((resolve, reject) => {
       this.httpClient.request<PreviewResponse>(token, (e, result) => {
         if (e) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,15 +1,14 @@
 import { Document } from "./documents";
-import ResolvedApi, { QueryOptions, EXPERIMENT_COOKIE, PREVIEW_COOKIE } from './ResolvedApi';
+import ResolvedApi, { QueryOptions } from './ResolvedApi';
 import ApiSearchResponse from './ApiSearchResponse';
-import { SearchForm, LazySearchForm } from './form';
-import { Experiment } from './experiments';
-import { RequestHandler, RequestCallback } from './request';
+import { LazySearchForm } from './form';
+import { RequestCallback } from './request';
 import Api, { ApiOptions } from './Api';
 import { PreviewResolver, createPreviewResolver } from './PreviewResolver';
 
 export interface Client {
-  query(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
-  queryFirst(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<Document>, cb: RequestCallback<Document>): Promise<Document>;
+  query(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
+  queryFirst(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document>;
   getByID(id: string, options: QueryOptions, cb: RequestCallback<Document>): Promise<Document>;
   getByIDs(ids: string[], options: QueryOptions, cb: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
   getByUID(type: string, uid: string, options: QueryOptions, cb: RequestCallback<Document>): Promise<Document>;
@@ -22,7 +21,6 @@ export interface Client {
 export class DefaultClient implements Client {
 
   api: Api;
-  resolvedApi: ResolvedApi;
 
   constructor(url: string, options?: ApiOptions) {
     this.api = new Api(url, options);
@@ -40,11 +38,11 @@ export class DefaultClient implements Client {
     return new LazySearchForm(formId, this.api);
   }
 
-  query(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse> {
+  query(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse> {
     return this.getApi().then(api => api.query(q, optionsOrCallback, cb));
   }
 
-  queryFirst(q: string | string[], optionsOrCallback: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document> {
+  queryFirst(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document> {
     return this.getApi().then(api => api.queryFirst(q, optionsOrCallback, cb));
   }
 


### PR DESCRIPTION
This PR
- fixes query definition to be optional for second parameter. Currently all tests and documentation marks the second parameter as optional for `query` and `queryfirst`
- cleans up imports
- cleans up some small inconsistencies: double-quotes, spelling mistakes, semicolons