### PR TITLE
preview-resolver: return document.url or use linkResolver

### DIFF
--- a/src/PreviewResolver.ts
+++ b/src/PreviewResolver.ts
@@ -15,13 +15,15 @@ export function createPreviewResolver(
   getDocByID?: (documentId: string, maybeOptions?: object) => Promise<Document>
 ): PreviewResolver {
   const resolve = (linkResolver: LinkResolver, defaultUrl: string, cb?: RequestCallback<string>) => {
+    console.log({ resolve: true, documentId, getDocByID })
     if (documentId && getDocByID) {
       return getDocByID(documentId, { ref: token }).then((document: Document) => {
         if (!document) {
           cb && cb(null, defaultUrl);
           return defaultUrl;
         } else {
-          const url = linkResolver(document);
+          console.log({ document })
+          const url = document.url || linkResolver(document);
           cb && cb(null, url);
           return url;
         }

--- a/src/documents.ts
+++ b/src/documents.ts
@@ -8,6 +8,7 @@ export interface AlternateLanguage {
 export interface Document {
   id: string;
   uid?: string;
+  url?: string;
   type: string;
   href: string;
   tags: string[];


### PR DESCRIPTION
Instantiating the API with a `routes` object enables routes resolving via the API. In that case, `getPreviewSession` should not call linkResolver but return `document.url`.