### PR TITLE
preview-resolver: use linkResolver or return document.url

### DIFF
--- a/src/PreviewResolver.ts
+++ b/src/PreviewResolver.ts
@@ -21,9 +21,7 @@ export function createPreviewResolver(
           cb && cb(null, defaultUrl);
           return defaultUrl;
         } else {
-          const url = linkResolver
-            ? linkResolver(document)
-            : document.url || defaultUrl;
+          const url = (linkResolver && linkResolver(document)) || document.url || defaultUrl
           cb && cb(null, url);
           return url;
         }

--- a/src/PreviewResolver.ts
+++ b/src/PreviewResolver.ts
@@ -21,7 +21,7 @@ export function createPreviewResolver(
           cb && cb(null, defaultUrl);
           return defaultUrl;
         } else {
-          const url = linkResolver(document);
+          const url = document.url || linkResolver(document);
           cb && cb(null, url);
           return url;
         }

--- a/src/PreviewResolver.ts
+++ b/src/PreviewResolver.ts
@@ -1,7 +1,7 @@
 import { Document } from "./documents";
 import { RequestCallback } from './request';
 
-export type LinkResolver = (doc: any) => string;
+export type LinkResolver = (doc: any) => string | null;
 
 export interface PreviewResolver {
   token: string;
@@ -21,7 +21,9 @@ export function createPreviewResolver(
           cb && cb(null, defaultUrl);
           return defaultUrl;
         } else {
-          const url = document.url || linkResolver(document);
+          const url = linkResolver
+            ? linkResolver(document)
+            : document.url || defaultUrl;
           cb && cb(null, url);
           return url;
         }

--- a/src/PreviewResolver.ts
+++ b/src/PreviewResolver.ts
@@ -1,7 +1,7 @@
 import { Document } from "./documents";
 import { RequestCallback } from './request';
 
-export type LinkResolver = (doc: any) => string | null;
+export type LinkResolver = ((doc: any) => string) | null;
 
 export interface PreviewResolver {
   token: string;

--- a/src/ResolvedApi.ts
+++ b/src/ResolvedApi.ts
@@ -243,7 +243,9 @@ export default class ResolvedApi implements Client {
                 cb && cb(null, defaultUrl);
                 resolve(defaultUrl);
               } else {
-                const url = linkResolver(document);
+                const url = linkResolver
+                  ? linkResolver(document)
+                  : document.url || defaultUrl;
                 cb && cb(null, url);
                 resolve(url);
               }

--- a/src/ResolvedApi.ts
+++ b/src/ResolvedApi.ts
@@ -243,9 +243,7 @@ export default class ResolvedApi implements Client {
                 cb && cb(null, defaultUrl);
                 resolve(defaultUrl);
               } else {
-                const url = linkResolver
-                  ? linkResolver(document)
-                  : document.url || defaultUrl;
+                const url = (linkResolver && linkResolver(document)) || document.url || defaultUrl
                 cb && cb(null, url);
                 resolve(url);
               }

--- a/src/documents.ts
+++ b/src/documents.ts
@@ -8,6 +8,7 @@ export interface AlternateLanguage {
 export interface Document {
   id: string;
   uid?: string;
+  url?: string;
   type: string;
   href: string;
   tags: string[];


### PR DESCRIPTION
Instantiating the API with a routes object enables routes resolving via the API. In that case, getPreviewSession should return document.url if not linkResolver does not resolve.

```javascript
const api = await Prismic.api({ routes: [{ type: 'page', path: '/:uid'}] })

const previewResolver = await api.getPreviewResolver(token, documentId)
const url = await previewResolver.resolve(null, '/')

console.log({ url }) // /some-uid or /

```