### PR TITLE
Fix getPreviewResolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "check": "tsc --pretty --noEmit --watch",
     "test": "npm run build && mocha",
     "prepare": "npm run build; npm run docs; npm run declarations",
-    "prepublishOnly": "npm run test && npm run prepare",
+    "prepublishOnly": "npm run test",
     "docs": "typedoc --mode file --out ./docs ./src/index.ts",
     "declarations": "tsc --emitDeclarationOnly --declaration --declarationDir ./types",
     "lint": "eslint src/**/*.ts"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "dev": "rollup -c -w",
     "check": "tsc --pretty --noEmit --watch",
     "test": "npm run build && mocha",
-    "prepublish": "npm run build; npm run docs; npm run declarations",
+    "prepare": "npm run build; npm run docs; npm run declarations",
+    "prepublishOnly": "npm run test && npm run prepare",
     "docs": "typedoc --mode file --out ./docs ./src/index.ts",
     "declarations": "tsc --emitDeclarationOnly --declaration --declarationDir ./types",
     "lint": "eslint src/**/*.ts"

--- a/src/client.ts
+++ b/src/client.ts
@@ -71,8 +71,8 @@ export class DefaultClient implements Client {
   }
 
   getPreviewResolver(token: string, documentId?: string): PreviewResolver {
-    const getDocById = (documentId: string) => this.getApi().then((api) => {
-      return api.getByID(documentId);
+    const getDocById = (documentId: string, maybeOptions?: QueryOptions) => this.getApi().then((api) => {
+      return api.getByID(documentId, maybeOptions);
     });
     return createPreviewResolver(token, documentId, getDocById);
   }


### PR DESCRIPTION
When using the `Client` interface, it seems we never overrides the ref with the preview token.
This causes some trouble mainly when previewing unpublished documents (not redirected to the right page).