### PR TITLE
Validate preview token in previewSession function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-- '8'
 - '10'
 - '12'
+- '14'
 os:
   - linux
 

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -50,7 +50,7 @@ export default class Api {
    */
   get(cb?: RequestCallback<ResolvedApi>): Promise<ResolvedApi> {
     return this.httpClient.cachedRequest<ApiData>(this.url, { ttl: this.apiDataTTL }).then((data) => {
-      const resolvedApi = new ResolvedApi(data, this.httpClient, this.options);
+      const resolvedApi = new ResolvedApi(data, this.url, this.httpClient, this.options);
       cb && cb(null, resolvedApi);
       return resolvedApi;
     }).catch((error) => {

--- a/src/PreviewResolver.ts
+++ b/src/PreviewResolver.ts
@@ -21,7 +21,7 @@ export function createPreviewResolver(
           cb && cb(null, defaultUrl);
           return defaultUrl;
         } else {
-          const url = (linkResolver && linkResolver(document)) || document.url || defaultUrl
+          const url = (linkResolver && linkResolver(document)) || document.url || defaultUrl
           cb && cb(null, url);
           return url;
         }

--- a/src/ResolvedApi.ts
+++ b/src/ResolvedApi.ts
@@ -260,7 +260,7 @@ export default class ResolvedApi implements Client {
                 cb && cb(null, defaultUrl);
                 resolve(defaultUrl);
               } else {
-                const url = (linkResolver && linkResolver(document)) || document.url || defaultUrl
+                const url = (linkResolver && linkResolver(document)) || document.url || defaultUrl
                 cb && cb(null, url);
                 resolve(url);
               }

--- a/src/ResolvedApi.ts
+++ b/src/ResolvedApi.ts
@@ -228,24 +228,21 @@ export default class ResolvedApi implements Client {
     return createPreviewResolver(token, documentId, this.getByID.bind(this));
   }
 
+  private validatePreviewToken(token: string): boolean {
+    try {
+      const hostToken = new URL(token).host.replace('.cdn', '');
+      const hostPrismicEndpoint = new URL(this.url).host.replace('.cdn', '');
+      return hostToken === hostPrismicEndpoint;
+    } catch(e) {
+      return false;
+    }
+  }
+
   previewSession(token: string, linkResolver: LinkResolver, defaultUrl: string, cb?: RequestCallback<string>): Promise<string> {
     console.warn('previewSession function is deprecated in favor of getPreviewResolver function.');
 
-    // Extract API host.
-    // The easiest way here would be to use `URL`, but it is not widely
-    // supported by Internet Explorer at the time of writing this fix.
-    // See: https://developer.mozilla.org/fr/docs/Web/API/URL/URL
-    const protocol = this.url.slice(0, this.url.indexOf('://') + 3);
-    const pathIdx = this.url.indexOf('/', protocol.length);
-    const targetHost = pathIdx < 0 ? this.url : this.url.slice(0, pathIdx);
-    const tokenPrefix = `${targetHost}/`;
-
-    // Check that the token points to a valid host
-    // Do not use `startsWith` method as it is not supported in Internet Explorer.
-    if (token.slice(0, tokenPrefix.length) !== tokenPrefix) {
-      return Promise.reject(new Error(
-        `The token should starts with: ${tokenPrefix}`
-      ));
+    if (!this.validatePreviewToken(token)) {
+      return Promise.reject(new Error('Invalid token'));
     }
 
     return new Promise((resolve, reject) => {

--- a/test/api.js
+++ b/test/api.js
@@ -186,6 +186,19 @@ describe('Api', function() {
     }).catch(done);
   });
 
+  it('should fail to resolve external URL', async function() {
+    const linkResolver = (doc) => `/${doc.uid}`;
+    const token = 'https://google.fr';
+    const api = await getApi();
+
+    try {
+      await api.previewSession(token, linkResolver, '/');
+      assert.fail('An external URL should not be resolved');
+    } catch (e) {
+      assert.equal(e.message, 'The token should starts with: http://localhost:3000/');
+    }
+  });
+
   it('should resolve the previewed document', async function() {
     const linkResolver = (doc) => `/${doc.uid}`;
     const token = "WJr3eikAAClRybU5~WYx9HB8AAB8AmX7z";

--- a/test/request.js
+++ b/test/request.js
@@ -33,13 +33,13 @@ describe('request', () => {
     nock(/example\.prismic\.io/)
     .get('/api/v2')
     .reply((uri, requestBody, cb) => {
-      setTimeout(() => cb(null, [200, STUB_RESPONSE]), 50)
-    })
+      setTimeout(() => cb(null, [200, STUB_RESPONSE]), 50);
+    });
 
     Prismic.getApi('https://example.prismic.io/api/v2', { timeoutInMs: 10 })
     .catch(err => {
-      assert.equal(err.toString(), 'Error: https://example.prismic.io/api/v2 response timeout')
-      done()
-    })
+      assert.equal(err.toString(), 'Error: https://example.prismic.io/api/v2 response timeout');
+      done();
+    });
   });
 });


### PR DESCRIPTION
The `previewSession` function uses the token as an URL to get more information about the preview itself. This can lead to security issue. This function has been deprecated some weeks ago for other reasons. It's still a good idea to fix it since we can't prevent people from using it for now.