### PR TITLE
fix: use access_token URL parameter over Authorization header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -10,8 +10,10 @@ import {
 	HttpRequestLike,
 	Query,
 	Ref,
-	Repository,
-	RequestInitLike
+	Repository
+	// TODO: Uncomment when the Authorization header can be used
+	// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+	// RequestInitLike
 } from "./types";
 import { buildQueryURL, BuildQueryURLArgs } from "./buildQueryURL";
 import { ForbiddenError, isForbiddenErrorAPIResponse } from "./ForbiddenError";
@@ -416,7 +418,10 @@ export class Client {
 	): Promise<Query<TDocument>> {
 		const url = await this.buildQueryURL(params);
 
-		return await this.fetch<Query<TDocument>>(url, params);
+		// TODO: Uncomment when the Authorization header can be used
+		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+		// return await this.fetch<Query<TDocument>>(url, params);
+		return await this.fetch<Query<TDocument>>(url);
 	}
 
 	/**
@@ -893,15 +898,23 @@ export class Client {
 	async buildQueryURL(
 		params: Partial<BuildQueryURLArgs> = {}
 	): Promise<string> {
+		// TODO: Uncomment when the Authorization header can be used
+		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+		// const {
+		// 	ref = await this.getResolvedRefString(),
+		// 	accessToken: _accessToken,
+		// 	...actualParams
+		// } = params;
 		const {
 			ref = await this.getResolvedRefString(),
-			accessToken: _accessToken,
+			accessToken = this.accessToken,
 			...actualParams
 		} = params;
 
 		return buildQueryURL(this.endpoint, {
 			...this.defaultParams,
 			...actualParams,
+			accessToken,
 			ref
 		});
 	}
@@ -1167,15 +1180,17 @@ export class Client {
 	 *
 	 * @returns Request options that can be used to make a network request to query the repository.
 	 */
-	private buildRequestOptions(
-		params?: Partial<BuildQueryURLArgs>
-	): RequestInitLike {
-		const accessToken = params?.accessToken || this.accessToken;
+	// TODO: Uncomment when the Authorization header can be used
+	// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+	// private buildRequestOptions(
+	// 	params?: Partial<BuildQueryURLArgs>
+	// ): RequestInitLike {
+	// 	const accessToken = params?.accessToken || this.accessToken;
 
-		return accessToken
-			? { headers: { Authorization: `Token ${accessToken}` } }
-			: {};
-	}
+	// 	return accessToken
+	// 		? { headers: { Authorization: `Token ${accessToken}` } }
+	// 		: {};
+	// }
 
 	/**
 	 * Performs a network request using the configured `fetch` function. It assumes all successful responses will have a JSON content type. It also normalizes unsuccessful network requests.
@@ -1187,11 +1202,16 @@ export class Client {
 	 * @returns The JSON response from the network request.
 	 */
 	private async fetch<T = unknown>(
-		url: string,
-		params?: Partial<BuildQueryURLArgs>
+		url: string
+		// TODO: Uncomment when the Authorization header can be used
+		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+		// params?: Partial<BuildQueryURLArgs>
 	): Promise<T> {
-		const options = this.buildRequestOptions(params);
-		const res = await this.fetchFn(url, options);
+		// TODO: Uncomment when the Authorization header can be used
+		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+		// const options = this.buildRequestOptions(params);
+		// const res = await this.fetchFn(url, options);
+		const res = await this.fetchFn(url);
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		let json: any;

--- a/src/client.ts
+++ b/src/client.ts
@@ -781,7 +781,17 @@ export class Client {
 	 * @returns Repository metadata.
 	 */
 	async getRepository(): Promise<Repository> {
-		return await this.fetch<Repository>(this.endpoint);
+		// TODO: Uncomment when the Authorization header can be used
+		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+		// return await this.fetch<Repository>(this.endpoint);
+
+		const url = new URL(this.endpoint);
+
+		if (this.accessToken) {
+			url.searchParams.set("access_token", this.accessToken);
+		}
+
+		return await this.fetch<Repository>(url.toString());
 	}
 
 	/**

--- a/test/__testutils__/createMockRepositoryHandler.ts
+++ b/test/__testutils__/createMockRepositoryHandler.ts
@@ -2,8 +2,8 @@ import * as ava from "ava";
 import * as msw from "msw";
 import * as crypto from "crypto";
 
-import { createAuthorizationHeader } from "./createAuthorizationHeader";
 import { createRepositoryResponse } from "./createRepositoryResponse";
+import { isValidAccessToken } from "./isValidAccessToken";
 
 export const createMockRepositoryHandler = (
 	t: ava.ExecutionContext,
@@ -14,11 +14,7 @@ export const createMockRepositoryHandler = (
 	const endpoint = `https://${repositoryName}.cdn.prismic.io/api/v2`;
 
 	return msw.rest.get(endpoint, (req, res, ctx) => {
-		if (
-			typeof accessToken === "string" &&
-			req.headers.get("Authorization") !==
-				createAuthorizationHeader(accessToken)
-		) {
+		if (!isValidAccessToken(accessToken, req)) {
 			return res(ctx.status(401));
 		}
 

--- a/test/__testutils__/isValidAccessToken.ts
+++ b/test/__testutils__/isValidAccessToken.ts
@@ -1,0 +1,20 @@
+import * as msw from "msw";
+
+// TODO: Uncomment when the Authorization header can be used
+// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+// import { createAuthorizationHeader } from "./createAuthorizationHeader";
+
+export const isValidAccessToken = (
+	accessToken: string | undefined,
+	req: msw.RestRequest
+): boolean => {
+	// TODO: Uncomment when the Authorization header can be used
+	// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+	// return typeof accessToken === "string"
+	// 	? req.headers.get("Authorization") ===
+	// 			createAuthorizationHeader(accessToken)
+	// 	: true;
+	return typeof accessToken === "string"
+		? req.url.searchParams.get("access_token") === accessToken
+		: true;
+};

--- a/test/client-buildQueryURL.test.ts
+++ b/test/client-buildQueryURL.test.ts
@@ -41,7 +41,10 @@ test("includes params if provided", async t => {
 
 	const expectedSearchParams = new URLSearchParams({
 		ref: params.ref,
-		lang: params.lang?.toString() ?? ""
+		lang: params.lang?.toString() ?? "",
+		// TODO: Remove when the Authorization header can be used
+		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+		access_token: params.accessToken ?? ""
 	});
 
 	t.is(url.host, new URL(client.endpoint).host);
@@ -64,7 +67,10 @@ test("includes default params if provided", async t => {
 
 	const expectedSearchParams = new URLSearchParams({
 		ref: clientOptions.ref?.toString() ?? "",
-		lang: clientOptions.defaultParams?.lang?.toString() ?? ""
+		lang: clientOptions.defaultParams?.lang?.toString() ?? "",
+		// TODO: Remove when the Authorization header can be used
+		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+		access_token: clientOptions.accessToken ?? ""
 	});
 
 	t.is(url.host, new URL(client.endpoint).host);
@@ -91,7 +97,10 @@ test("merges params and default params if provided", async t => {
 	const expectedSearchParams = new URLSearchParams({
 		ref: params.ref,
 		lang: clientOptions.defaultParams?.lang?.toString() ?? "",
-		page: clientOptions.defaultParams?.page?.toString() ?? ""
+		page: clientOptions.defaultParams?.page?.toString() ?? "",
+		// TODO: Remove when the Authorization header can be used
+		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+		access_token: clientOptions.accessToken ?? ""
 	});
 
 	t.is(url.host, new URL(client.endpoint).host);

--- a/test/client-getRepository.test.ts
+++ b/test/client-getRepository.test.ts
@@ -5,6 +5,8 @@ import { createMockRepositoryHandler } from "./__testutils__/createMockRepositor
 import { createRepositoryResponse } from "./__testutils__/createRepositoryResponse";
 import { createTestClient } from "./__testutils__/createClient";
 
+import * as prismic from "../src";
+
 const server = mswNode.setupServer();
 test.before(() => server.listen({ onUnhandledRequest: "error" }));
 test.after(() => server.close());
@@ -14,6 +16,22 @@ test("returns repository metadata", async t => {
 	server.use(createMockRepositoryHandler(t, response));
 
 	const client = createTestClient(t);
+	const res = await client.getRepository();
+
+	t.deepEqual(res, response);
+});
+
+// TODO: Remove when the Authorization header can be used
+// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
+test("includes access token if configured", async t => {
+	const options: prismic.ClientConfig = {
+		accessToken: "accessToken"
+	};
+
+	const response = createRepositoryResponse();
+	server.use(createMockRepositoryHandler(t, response, options.accessToken));
+
+	const client = createTestClient(t, options);
 	const res = await client.getRepository();
 
 	t.deepEqual(res, response);


### PR DESCRIPTION
This PR replaces the Authorization header with the `access_token` URL parameter to authenticate requests. It includes temporary comments to restore Authorization header use when the API is ready.

The REST API currently does not fully support the Authorization header for the following reasons:

- **CORS**: CORS preflight requests fail either due to the Authorization header not being sent or an invalid CORS server configuration.
- **CDN Support**: Some repositories do not support the Authorization header on the CDN endpoints.

Related internal issue: https://github.com/prismicio/issue-tracker-wroom/issues/351