### PR TITLE
feat: add support httpOptions for fetch

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import { getCookie } from "./lib/getCookie";
 import {
 	FetchLike,
 	Form,
+	HttpOptionsLike,
 	HttpRequestLike,
 	Query,
 	Ref,
@@ -168,6 +169,8 @@ export type ClientConfig = {
 	 * The function used to make network requests to the Prismic REST API. In environments where a global `fetch` function does not exist, such as Node.js, this function must be provided.
 	 */
 	fetch?: FetchLike;
+
+	httpOptions?: httpOptionsLike;
 };
 
 /**
@@ -280,6 +283,8 @@ export class Client {
 	 */
 	fetchFn: FetchLike;
 
+	httpOptions: HttpOptionsLike;
+
 	/**
 	 * Default parameters that will be sent with each query. These parameters can be overridden on each query if needed.
 	 */
@@ -309,6 +314,7 @@ export class Client {
 		this.endpoint = endpoint;
 		this.accessToken = options.accessToken;
 		this.defaultParams = options.defaultParams;
+		this.httpOptions = options.httpOptions;
 		this.internalCache = createSimpleTTLCache();
 		this.refMode = {
 			type: RefStateType.Master,
@@ -421,7 +427,7 @@ export class Client {
 		// TODO: Uncomment when the Authorization header can be used
 		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
 		// return await this.fetch<Query<TDocument>>(url, params);
-		return await this.fetch<Query<TDocument>>(url);
+		return await this.fetch<Query<TDocument>>(url, this.httpOptions);
 	}
 
 	/**
@@ -791,7 +797,7 @@ export class Client {
 			url.searchParams.set("access_token", this.accessToken);
 		}
 
-		return await this.fetch<Repository>(url.toString());
+		return await this.fetch<Repository>(url.toString(), this.httpOptions);
 	}
 
 	/**
@@ -890,7 +896,7 @@ export class Client {
 		try {
 			const tagsForm = await this.getCachedRepositoryForm("tags");
 
-			return await this.fetch<string[]>(tagsForm.action);
+			return await this.fetch<string[]>(tagsForm.action, this.httpOptions);
 		} catch {
 			const res = await this.getRepository();
 
@@ -1224,7 +1230,7 @@ export class Client {
 		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
 		// const options = this.buildRequestOptions(params);
 		// const res = await this.fetchFn(url, options);
-		const res = await this.fetchFn(url);
+		const res = await this.fetchFn(url, this.httpOptions);
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		let json: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as prismicT from "@prismicio/types";
+import { Agent } from "http";
 
 export interface Ref {
 	ref: string;
@@ -67,6 +68,14 @@ export type FetchLike = (
 	input: string,
 	init?: RequestInitLike,
 ) => Promise<ResponseLike>;
+
+/**
+ * Http options we need to perform a request
+ * @link https://github.com/node-fetch/node-fetch/blob/main/%40types/index.d.ts#L76
+ */
+export interface HttpOptionsLike {
+	agent?: Agent | ((parsedUrl: URL) => Agent);
+}
 
 /**
  * The minimum required properties from RequestInit.


### PR DESCRIPTION
Hey :wave: 

We use the gatsby-source-prismic plugin, it doesn't work inside our CI because there is no support  for Agent inside (a PR is coming). 

While I was reading the source I found this one doesn't support agent anymore (v5 does).

cf https://nodejs.org/api/https.html#https_class_https_agent we need this to be able to use the plugin as we have a proxy inside our runner.
