### PR TITLE
refactor: simplify repository caching

### DIFF
--- a/test/client-getMasterRef.test.ts
+++ b/test/client-getMasterRef.test.ts
@@ -20,5 +20,5 @@ it("shares concurrent equivalent network requests", async ({
 		client.getMasterRef({ signal: controller2.signal }),
 	])
 	await client.getMasterRef()
-	expect(client).toHaveFetchedRepoTimes(4)
+	expect(client).toHaveFetchedRepoTimes(3)
 })

--- a/test/client-getRefByID.test.ts
+++ b/test/client-getRefByID.test.ts
@@ -35,5 +35,5 @@ it("shares concurrent equivalent network requests", async ({
 		client.getRefByID(release.id, { signal: controller2.signal }),
 	])
 	await client.getRefByID(release.id)
-	expect(client).toHaveFetchedRepoTimes(4)
+	expect(client).toHaveFetchedRepoTimes(3)
 })

--- a/test/client-getRefByLabel.test.ts
+++ b/test/client-getRefByLabel.test.ts
@@ -37,5 +37,5 @@ it("shares concurrent equivalent network requests", async ({
 		client.getRefByLabel(release.label, { signal: controller2.signal }),
 	])
 	await client.getRefByLabel(release.label)
-	expect(client).toHaveFetchedRepoTimes(4)
+	expect(client).toHaveFetchedRepoTimes(3)
 })

--- a/test/client-getRefs.test.ts
+++ b/test/client-getRefs.test.ts
@@ -22,5 +22,5 @@ it("shares concurrent equivalent network requests", async ({
 		client.getRefs({ signal: controller2.signal }),
 	])
 	await client.getRefs()
-	expect(client).toHaveFetchedRepoTimes(4)
+	expect(client).toHaveFetchedRepoTimes(3)
 })

--- a/test/client-getReleaseById.test.ts
+++ b/test/client-getReleaseById.test.ts
@@ -37,5 +37,5 @@ it("shares concurrent equivalent network requests", async ({
 		client.getReleaseByID(release.id, { signal: controller2.signal }),
 	])
 	await client.getReleaseByID(release.id)
-	expect(client).toHaveFetchedRepoTimes(4)
+	expect(client).toHaveFetchedRepoTimes(3)
 })

--- a/test/client-getReleaseByLabel.test.ts
+++ b/test/client-getReleaseByLabel.test.ts
@@ -42,5 +42,5 @@ it("shares concurrent equivalent network requests", async ({
 		client.getReleaseByLabel(release.label, { signal: controller2.signal }),
 	])
 	await client.getReleaseByLabel(release.label)
-	expect(client).toHaveFetchedRepoTimes(4)
+	expect(client).toHaveFetchedRepoTimes(3)
 })

--- a/test/client-getReleases.test.ts
+++ b/test/client-getReleases.test.ts
@@ -24,5 +24,5 @@ it("shares concurrent equivalent network requests", async ({
 		client.getReleases({ signal: controller2.signal }),
 	])
 	await client.getReleases()
-	expect(client).toHaveFetchedRepoTimes(4)
+	expect(client).toHaveFetchedRepoTimes(3)
 })

--- a/test/client-getRepository.test.ts
+++ b/test/client-getRepository.test.ts
@@ -49,5 +49,5 @@ it("shares concurrent equivalent network requests", async ({
 		client.getRepository({ signal: controller2.signal }),
 	])
 	await client.getRepository()
-	expect(client).toHaveFetchedRepoTimes(4)
+	expect(client).toHaveFetchedRepoTimes(3)
 })


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: N/A

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR simplifies how repository metadata is cached. Cache duration remains the same, but `getRepository()` now uses the cached repository if it is available and within the cache window.

The simplification results in one less network call in some situations, like when sharing concurrent network requests.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
