### PR TITLE
fix: move `NODE_ENV` checks first to fix treeshaking artifacts

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -302,8 +302,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 			)
 		}
 		if (
-			/\.prismic\.io\/(?!api\/v2\/?)/i.test(this.documentAPIEndpoint) &&
-			process.env.NODE_ENV === "development"
+			process.env.NODE_ENV === "development" &&
+			/\.prismic\.io\/(?!api\/v2\/?)/i.test(this.documentAPIEndpoint)
 		) {
 			throw new PrismicError(
 				"@prismicio/client only supports Prismic Rest API V2. Please provide only the repository name to the first createClient() parameter or use the getRepositoryEndpoint() helper to generate a valid Rest API V2 endpoint URL.",
@@ -312,10 +312,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 			)
 		}
 		if (
+			process.env.NODE_ENV === "development" &&
 			/(?<!\.cdn)\.prismic\.io$/i.test(
 				new URL(this.documentAPIEndpoint).hostname,
-			) &&
-			process.env.NODE_ENV === "development"
+			)
 		) {
 			console.warn(
 				`[@prismicio/client] The client was created with a non-CDN endpoint. Convert it to the CDN endpoint for better performance. For more details, see ${devMsg("endpoint-must-use-cdn")}`,


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: #424

### Description

It appears that treeshaking can leave artifacts in clauses when static checks come last. This PR fixes that by moving the `NODE_ENV` checks first, which should hopefully clean up the treeshaking artifacts.

See: https://rollupjs.org/repl/?version=4.54.0&shareable=eyJleGFtcGxlIjpudWxsLCJtb2R1bGVzIjpbeyJjb2RlIjoiaWYgKC8oPzwhXFwuY2RuKVxcLnByaXNtaWNcXC5pbyQvaS50ZXN0KG5ldyBVUkwoXCJoYXMgYXJ0aWZhY3RzXCIpLmhvc3RuYW1lKSAmJiBmYWxzZSkge31cblxuaWYgKGZhbHNlICYmIC8oPzwhXFwuY2RuKVxcLnByaXNtaWNcXC5pbyQvaS50ZXN0KG5ldyBVUkwoXCJhcnRpZmFjdC1mcmVlXCIpLmhvc3RuYW1lKSkge30iLCJpc0VudHJ5Ijp0cnVlLCJuYW1lIjoibWFpbi5qcyJ9XSwib3B0aW9ucyI6eyJvdXRwdXQiOnsiZm9ybWF0IjoiZXMifSwidHJlZXNoYWtlIjp0cnVlfX0=

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->
`npm install @prismicio/client@pr-425`

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
