### PR TITLE
fix: Use arrayBuffer instead of blob when memoizing responses

### DIFF
--- a/src/WriteClient.ts
+++ b/src/WriteClient.ts
@@ -633,10 +633,10 @@ export class WriteClient<
 			throw new PrismicError("Could not fetch foreign asset", url, undefined)
 		}
 
-		const blob = await res.blob()
+		const buffer = await res.arrayBuffer()
 
 		// Ensure a correct content type is attached to the blob.
-		return new File([blob], "", {
+		return new File([buffer], "", {
 			type: res.headers.get("content-type") || undefined,
 		})
 	}

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -93,6 +93,7 @@ export interface ResponseLike {
 	// oxlint-disable-next-line no-explicit-any
 	json(): Promise<any>
 	text(): Promise<string>
+	arrayBuffer(): Promise<ArrayBuffer>
 	blob(): Promise<Blob>
 	clone(): ResponseLike
 }
@@ -107,17 +108,18 @@ export interface HeadersLike {
 async function memoizeResponse(response: ResponseLike): Promise<ResponseLike> {
 	// Deduplicated responses are shared across multiple callers. Calling
 	// response.clone() on a shared response can cause backpressure hangs
-	// in Node.js, so we buffer the body as a blob upfront instead.
-	const blob = await response.blob()
+	// in Node.js, so we buffer the body as an ArrayBuffer upfront instead.
+	const buffer = await response.arrayBuffer()
 
 	const memoized: ResponseLike = {
 		ok: response.ok,
 		status: response.status,
 		headers: response.headers,
 		url: response.url,
-		text: async () => blob.text(),
-		json: async () => JSON.parse(await blob.text()),
-		blob: async () => blob,
+		text: async () => new TextDecoder().decode(buffer),
+		json: async () => JSON.parse(new TextDecoder().decode(buffer)),
+		arrayBuffer: async () => buffer,
+		blob: async () => new Blob([buffer]),
 		clone: () => memoized,
 	}
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: React native compatibility <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

The react native blob implementation is apparently a bit lacking. The memoization introduced in #437 is using some functions that do not exist in the react native blob.

Resulting in the following errors:
```
TypeError: _blob.text is not a function (it is undefined)
```

This change uses the `response.arrayBuffer()` combined with `TextEncoder`.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `request()` deduplication/memoization path to buffer bodies as `ArrayBuffer`, which could affect response decoding and memory usage across all callers. Risk is moderate because it touches shared HTTP plumbing but is a localized behavioral swap.
> 
> **Overview**
> Fixes response memoization to be React Native compatible by buffering deduplicated responses using `response.arrayBuffer()` instead of `response.blob()`.
> 
> `memoizeResponse()` now reconstructs `text()`/`json()` via `TextDecoder`, exposes `arrayBuffer()`, and recreates `blob()` from the buffered bytes; `WriteClient.fetchForeignAsset()` is updated to build `File` objects from an `ArrayBuffer` rather than a `Blob`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71c6c7eefea13e189fc275dea71b469672fe434f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->